### PR TITLE
Fix switch statement 🔀

### DIFF
--- a/lib/server/server.ts
+++ b/lib/server/server.ts
@@ -145,24 +145,12 @@ class MulticolourServer {
     return this
   }
 
-  private getEnumValueFromRequest(method?: string): Multicolour$RouteVerbs {
-    switch (method) {
-    case "POST":
-        return Multicolour$RouteVerbs.POST
-    case "PUT":
-        return Multicolour$RouteVerbs.PUT
-    case "PATCH":
-        return Multicolour$RouteVerbs.PATCH
-    case "OPTIONS":
-        return Multicolour$RouteVerbs.OPTIONS
-    case "HEAD":
-        return Multicolour$RouteVerbs.HEAD
-    case "DELETE":
-        return Multicolour$RouteVerbs.DELETE
-    case "GET":
-    default:
-        return Multicolour$RouteVerbs.GET
+  private getEnumValueFromRequest(inputMethod?: string): Multicolour$RouteVerbs {
+    var method : Multicolour$RouteVerbs = Multicolour$RouteVerbs[inputMethod as keyof typeof Multicolour$RouteVerbs];
+    if (!method) {
+      return Multicolour$RouteVerbs.GET
     }
+    return Multicolour$RouteVerbs[method]
   }
 }
 

--- a/lib/server/server.ts
+++ b/lib/server/server.ts
@@ -146,7 +146,7 @@ class MulticolourServer {
   }
 
   private getEnumValueFromRequest(inputMethod?: string): Multicolour$RouteVerbs {
-    var method : Multicolour$RouteVerbs = Multicolour$RouteVerbs[inputMethod as keyof typeof Multicolour$RouteVerbs];
+    const method: Multicolour$RouteVerbs = Multicolour$RouteVerbs[inputMethod as keyof typeof Multicolour$RouteVerbs]
     if (!method) {
       return Multicolour$RouteVerbs.GET
     }


### PR DESCRIPTION
### Description

This is a small PR to fix the switch statement as described in [this tweet](https://twitter.com/daveymackintosh/status/1111214740557258752). 

To verify this works, you can view the playground example [here](http://www.typescriptlang.org/play/index.html#src=%2F%2F%20This%20is%20an%20example%20for%20this%20PR%20-%20https%3A%2F%2Fgithub.com%2FMulticolour%2F1.0RC%2Fpull%2F4%0D%0A%0D%0Avar%20inputMethod%20%3D%20%22GET%22%20%2F%2F%20Change%20me%0D%0A%0D%0Aenum%20Multicolour%24RouteVerbs%20%7B%0D%0A%20%20GET%20%3D%20%22GET%22%2C%0D%0A%20%20POST%20%3D%20%22POST%22%2C%0D%0A%20%20PUT%20%3D%20%22PUT%22%2C%0D%0A%20%20PATCH%20%3D%20%22PATCH%22%2C%0D%0A%20%20DELETE%20%3D%20%22DELETE%22%2C%0D%0A%20%20OPTIONS%20%3D%20%22OPTIONS%22%2C%0D%0A%20%20HEAD%20%3D%20%22HEAD%22%2C%0D%0A%7D%0D%0A%0D%0A%2F%2F%20This%20takes%20the%20string%2C%20and%20forces%20it%20to%20convert%20to%20a%20key%20of%20the%20Multicolour%24RouteVerbs%20type%0D%0Avar%20method%20%3A%20Multicolour%24RouteVerbs%20%3D%20Multicolour%24RouteVerbs%5BinputMethod%20as%20keyof%20typeof%20Multicolour%24RouteVerbs%5D%3B%0D%0Aif%20(!method)%20%7B%20%2F%2F%20If%20the%20method%20doesn't%20work%2C%20this%20will%20be%20false%0D%0A%20%20%20%20alert(%22Defaulting%20to%20%22%20%2B%20Multicolour%24RouteVerbs.GET)%0D%0A%7D%20else%20%7B%0D%0A%20%20%20%20alert(Multicolour%24RouteVerbs%5Bmethod%5D)%20%2F%2F%20If%20the%20method%20does%20work%2C%20then%20wrap%20it%0D%0A%7D)

### Check List

- [ ] All test passed (master is failing, so this PRs test fails for the same reason)
